### PR TITLE
some quick fixes to youtube-dl-playlist

### DIFF
--- a/youtube-dl-playlist
+++ b/youtube-dl-playlist
@@ -82,9 +82,10 @@ print 'Total videos to download: ' + str(TOTAL_VIDEOS)
 ACTUAL_PATH = createPath(DESTINATION_PATH, data['feed']['title']['$t'])
 CURRENT_PATH = os.getcwd()
 
-if os.path.exists('/tmp/youtube-dl-playlist'):
-    shutil.rmtree('/tmp/youtube-dl-playlist', True)
-os.mkdir('/tmp/youtube-dl-playlist')
+workdir = '/tmp/youtube-dl-playlist'
+if os.path.exists(workdir):
+    shutil.rmtree(workdir, True)
+os.mkdir(workdir)
 
 existingFiles = os.listdir(ACTUAL_PATH)
 
@@ -110,15 +111,15 @@ while(i <= TOTAL_VIDEOS):
             print 'already exists'
         else:
             try:
-                os.chdir('/tmp/youtube-dl-playlist')
+                os.chdir(workdir)
                 os.system('youtube-dl -q http://www.youtube.com/watch?v=' + entry['media$group']['yt$videoid']['$t'])
-                files = os.listdir('/tmp/youtube-dl-playlist')
+                files = os.listdir(workdir)
                 for filename in files:
                     if filename.startswith(entry['media$group']['yt$videoid']['$t']) == True:
                         break
                 os.chdir(CURRENT_PATH)
                 os.rename(
-                    '/tmp/youtube-dl-playlist/' + filename,
+                    workdir+'/' + filename,
                     ACTUAL_PATH + '/' + newFilename + filename[-4:]
                 )
                 print 'done'
@@ -127,4 +128,4 @@ while(i <= TOTAL_VIDEOS):
         
         i = i + 1
 
-shutil.rmtree('/tmp/youtube-dl-playlist', True)
+shutil.rmtree(workdir, True)

--- a/youtube-dl-playlist
+++ b/youtube-dl-playlist
@@ -12,6 +12,7 @@ import httplib
 import json
 import os
 import shutil
+import tempfile
 
 def usage():
     print 'Usage: youtube-dl-playlist PLAYLIST_ID [DESTINATION_PATH]'
@@ -82,10 +83,7 @@ print 'Total videos to download: ' + str(TOTAL_VIDEOS)
 ACTUAL_PATH = createPath(DESTINATION_PATH, data['feed']['title']['$t'])
 CURRENT_PATH = os.getcwd()
 
-workdir = '/tmp/youtube-dl-playlist'
-if os.path.exists(workdir):
-    shutil.rmtree(workdir, True)
-os.mkdir(workdir)
+workdir = tempfile.mkdtemp(prefix="youtube-dl-playlist.")
 
 existingFiles = os.listdir(ACTUAL_PATH)
 

--- a/youtube-dl-playlist
+++ b/youtube-dl-playlist
@@ -118,7 +118,7 @@ while(i <= TOTAL_VIDEOS):
                 os.chdir(CURRENT_PATH)
                 os.rename(
                     workdir+'/' + filename,
-                    ACTUAL_PATH + '/' + newFilename + filename[-4:]
+                    ACTUAL_PATH + '/' + newFilename + '.' + filename[-4:]
                 )
                 print 'done'
             except Exception:


### PR DESCRIPTION
HI, thanks for writing youtube-dl-playlist.  I've made a small number of improvements for my own use:
- use a random, safe working directory name (to avoid symlink attacks)
- honour $TMPDIR and related variables (to provide control over which filesystem is used for the working directory)
- correct the appending of the filename suffix (include the separating '.')

Please consider this pull request.
